### PR TITLE
Hotfixes in getting rym charts

### DIFF
--- a/rymscraper/RymUrl.py
+++ b/rymscraper/RymUrl.py
@@ -30,5 +30,6 @@ class RymUrl:
             # + self.url_part_countries
             + self.page_separator
             + str(self.page)
+            + '/'
         )
         return final_url

--- a/rymscraper/__init__.py
+++ b/rymscraper/__init__.py
@@ -151,7 +151,7 @@ class RymNetwork:
                     break
 
                 # link to the next page
-                if soup.find("a", {"class": "navlinknext"}):
+                if soup.find("a", {"class": "ui_pagination_next"}):
                     logger.debug("Next page found")
                     if max_page and url.page == max_page:
                         break
@@ -198,8 +198,8 @@ class RymNetwork:
         complementary_infos: bool = False,
     ) -> List[Dict]:
         """Returns a list of dicts containing infos from several discography."""
+        list_artists_discos = []
         if names:
-            list_artists_discos = []
             for name in names:
                 artist_disco = self.get_discography_infos(
                     name=name, complementary_infos=complementary_infos

--- a/tests/test_RymUrl.py
+++ b/tests/test_RymUrl.py
@@ -4,7 +4,7 @@ from rymscraper import RymUrl
 def test_RymUrlSimple():
     RymUrlTest = RymUrl.RymUrl()
     print(str(RymUrlTest))
-    if str(RymUrlTest) != "https://rateyourmusic.com/charts/top/album/1":
+    if str(RymUrlTest) != "https://rateyourmusic.com/charts/top/album/1/":
         raise AssertionError()
 
 
@@ -17,6 +17,6 @@ def test_RymUrlAdvanced():
     print(str(RymUrlTest))
     if (
         str(RymUrlTest)
-        != "https://rateyourmusic.com/charts/top/release/2010s/g:rock/loc:france/1"
+        != "https://rateyourmusic.com/charts/top/release/2010s/g:rock/loc:france/1/"
     ):
         raise AssertionError()

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -9,16 +9,22 @@ from rymscraper import RymUrl
 )
 def test_chart_infos(network):
     url = RymUrl.RymUrl()
+    page_size = 40
+    max_page = 2
 
-    chart_infos = network.get_chart_infos(url, max_page=1)
+    chart_infos = network.get_chart_infos(url, max_page=max_page)
     print(len(chart_infos))
 
-    if not len(chart_infos) == 40:
+    if not len(chart_infos) == max_page * page_size:
         raise AssertionError()
 
     first_item = chart_infos[0]
+    second_page_item = chart_infos[page_size]
 
     if not first_item["Rank"] == "1":
+        raise AssertionError()
+
+    if not second_page_item["Rank"] == str(page_size + 1):
         raise AssertionError()
 
     if not first_item["Artist"] == "Radiohead":
@@ -34,8 +40,8 @@ def test_chart_infos(network):
         raise AssertionError()
 
     if (
-        not isinstance(first_item["RYM Rating"], str)
-        and "." in first_item["RYM Rating"]
+            not isinstance(first_item["RYM Rating"], str)
+            and "." in first_item["RYM Rating"]
     ):
         raise AssertionError()
 


### PR DESCRIPTION
Great tool, but found some issues while getting some rym charts data. So I decided to fixed them and create pull request.

### 1.  Missing '/' at the end of url address
For rym there is a diffrence between:
-  [https://rateyourmusic.com/charts/popular/album/2](https://rateyourmusic.com/charts/popular/album/2)
- and [https://rateyourmusic.com/charts/popular/album/2/](https://rateyourmusic.com/charts/popular/album/2/)

The first url (before fix) link to first page instead to second. Added '/' to the end of url fixed the issue.

### 2. Invalid class name in next page condition in get_chart_infos function
Solution: Updated class name to 'ui_pagination_next' in next page condition in get_chart_infos function (previous class name 'navlinknext' is no longer valid at the rym webpage). Also, in test_chart.py added checking out next page for rym charts.
