### PR TITLE
Add encoding parameter to not get error on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 import rymscraper
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
First of all, thanks for creating this very cool project!

If you currently want to install rymscraper on windows as a package over git like `pip install git+https://github.com/dbeley/rymscraper` (I tested it with poetry), you get an error because for windows the default encoding is not utf-8, which causes setup.py to crash when reading the description file. This PR should fix this.