### PR TITLE
Make charts url creator more user friendly + two bug fixes

### DIFF
--- a/examples/get_chart.py
+++ b/examples/get_chart.py
@@ -17,13 +17,14 @@ def main():
     Path(export_directory).mkdir(parents=True, exist_ok=True)
 
     if not args.url:
-        url = RymUrl.RymUrl()
+        
+        url = RymUrl.RymUrl(year=args.year, genres=args.genre, origin_countries=args.country)
         export_filename = f"{export_directory}/{int(time.time())}_export_chart"
         logger.debug("rym_url : %s.", url)
 
         if args.everything:
             export_filename += f"_everything"
-            url.url_part_type = f"/release"
+            url.kind = "release"
         else:
             export_filename += f"_album"
         if args.year:

--- a/rymscraper/RymUrl.py
+++ b/rymscraper/RymUrl.py
@@ -12,7 +12,8 @@ class RymUrl:
         return name.replace(" ", "-")
 
     def __init__(self, type="album", year="all-time", genres: str = None, origin_countries: str = None, language: str = None, descriptors: str = None, page=1):
-        self.url_base = "https://rateyourmusic.com/charts/top/"
+        """The language should be the 2 letter code for the language. For example, English is en, French is fr, etc."""
+        self.url_base = "https://rateyourmusic.com/charts/top"
 
         self.type = type
         self.year = year

--- a/rymscraper/RymUrl.py
+++ b/rymscraper/RymUrl.py
@@ -1,35 +1,32 @@
 # For now you will have to directly change the string values. Look at examples/get_chart.py for examples.
 # https://rateyourmusic.com/charts/top/release/1984-2002/g:ambient/loc:france/minr:200/
 # https://rateyourmusic.com/charts/top/album,ep,single,unauth,djmix/2010s/g:ambient,blues/d:atmosphere,form,theme,bittersweet,epic/s:classical%2dmusic/loc:algeria,bouvet%2disland%2dbouvetoya,europe,antarctica%2d1/minr:200/pop:5/
+from typing import Optional
+
+
 class RymUrl:
-    def __init__(self):
-        self.url_base = f"https://rateyourmusic.com/charts/top"
-        self.url_part_type = "/album"
-        self.url_part_year = ""
-        self.url_part_genres = ""
-        # self.url_part_include_child_genres_chk = "&include_child_genres_chk=1"
-        # self.url_part_include_both = "&include_both"
-        self.url_part_origin_countries = ""
-        # self.url_part_limit = "&limit=none"
-        # self.url_part_countries = "&countries="
-        self.page_separator = "/"
-        self.page = 1
+    @staticmethod
+    def sanitize_name(name: Optional[str]) -> Optional[str]:
+        if name is None:
+            return None
+        return name.replace(" ", "-")
+
+    def __init__(self, type="album", year="all-time", genres: str = None, origin_countries: str = None, language: str = None, descriptors: str = None, page=1):
+        self.url_base = "https://rateyourmusic.com/charts/top/"
+
+        self.type = type
+        self.year = year
+        self.genres = self.sanitize_name(genres)
+        self.origin_countries = self.sanitize_name(origin_countries)
+        self.language = self.sanitize_name(language)
+        self.descriptors = self.sanitize_name(descriptors)
+        self.page = page
 
     def __repr__(self):
-        final_url = (
-            self.url_base
-            + self.url_part_type
-            + self.url_part_year
-            # + self.url_part_genre_include
-            # + self.url_part_child_genres
-            + self.url_part_genres
-            # + self.url_part_include_child_genres_chk
-            # + self.url_part_include_both
-            + self.url_part_origin_countries
-            # + self.url_part_limit
-            # + self.url_part_countries
-            + self.page_separator
-            + str(self.page)
-            + "/"
-        )
+        genres = f"/g:{self.genres}" if self.genres else ""
+        origin_countries = f"/loc:{self.origin_countries}" if self.origin_countries else ""
+        language = f"/l:{self.language}" if self.language else ""
+        descriptors = f"/d:{self.descriptors}" if self.descriptors else ""
+        final_url = f"{self.url_base}/{self.type}/{self.year}{genres}{origin_countries}{language}{descriptors}/{self.page}/"
+
         return final_url

--- a/rymscraper/RymUrl.py
+++ b/rymscraper/RymUrl.py
@@ -11,11 +11,11 @@ class RymUrl:
             return None
         return name.replace(" ", "-")
 
-    def __init__(self, type="album", year="all-time", genres: str = None, origin_countries: str = None, language: str = None, descriptors: str = None, page=1):
+    def __init__(self, kind="album", year="all-time", genres: str = None, origin_countries: str = None, language: str = None, descriptors: str = None, page=1):
         """The language should be the 2 letter code for the language. For example, English is en, French is fr, etc."""
         self.url_base = "https://rateyourmusic.com/charts/top"
 
-        self.type = type
+        self.kind = kind
         self.year = year
         self.genres = self.sanitize_name(genres)
         self.origin_countries = self.sanitize_name(origin_countries)
@@ -28,6 +28,6 @@ class RymUrl:
         origin_countries = f"/loc:{self.origin_countries}" if self.origin_countries else ""
         language = f"/l:{self.language}" if self.language else ""
         descriptors = f"/d:{self.descriptors}" if self.descriptors else ""
-        final_url = f"{self.url_base}/{self.type}/{self.year}{genres}{origin_countries}{language}{descriptors}/{self.page}/"
+        final_url = f"{self.url_base}/{self.kind}/{self.year}{genres}{origin_countries}{language}{descriptors}/{self.page}/"
 
         return final_url

--- a/rymscraper/__init__.py
+++ b/rymscraper/__init__.py
@@ -1,5 +1,2 @@
 __version__ = "0.2.3"
 name = "rymscraper"
-from .RymBrowser import RymBrowser
-from .RymUrl import RymUrl
-from .rymscraper import RymNetwork

--- a/rymscraper/__init__.py
+++ b/rymscraper/__init__.py
@@ -1,2 +1,5 @@
 __version__ = "0.2.3"
 name = "rymscraper"
+from .RymBrowser import RymBrowser
+from .RymUrl import RymUrl
+from .rymscraper import RymNetwork

--- a/rymscraper/rymscraper.py
+++ b/rymscraper/rymscraper.py
@@ -104,7 +104,7 @@ class RymNetwork:
         return list_artists_infos
 
     def get_chart_infos(
-        self, url: Optional[str] = None, max_page: int = None
+        self, url: RymUrl.RymUrl, max_page: int = None
     ) -> List[Dict]:
         """Returns a list of dicts containing chart infos.
 

--- a/rymscraper/rymscraper.py
+++ b/rymscraper/rymscraper.py
@@ -131,7 +131,7 @@ class RymNetwork:
                     logger.debug("Table containing chart elements found")
                     table = soup.find("section", {"id": "page_charts_section_charts"})
                     rows = table.find_all(
-                        "div", {"class": "page_section_charts_item_wrapper anchor"}
+                        "div", {"class": "page_section_charts_item_wrapper"}
                     )
                     if len(rows) == 0:
                         logger.debug("No rows extracted. Exiting")

--- a/rymscraper/utils.py
+++ b/rymscraper/utils.py
@@ -176,10 +176,22 @@ def get_chart_row_infos(row: element.Tag) -> dict:
         logger.error("Error when fetching Rank: %s", e)
         dict_row["Rank"] = "NA"
     try:
-        dict_row["Artist"] = row.find(
+        artist_div = dict_row["Artist"] = row.find(
             "div",
             {"class": "page_charts_section_charts_item_credited_links_primary"},
-        ).text.replace("\n", "")
+        )
+        romanized_version_span = artist_div.find("span", {"class": "ui_name_locale_language"})
+            
+        original_name_span =  artist_div.find("span", {"class": "ui_name_locale_original"})
+        
+        if romanized_version_span:
+            dict_row["Artist"] = f"{romanized_version_span.text} [{original_name_span.text}]"
+        elif original_name_span:
+            dict_row["Artist"] = original_name_span.text
+        else:
+            dict_row["Artist"] = artist_div.text
+        
+        dict_row["Artist"] = dict_row["Artist"].replace("\n", "")
     except Exception as e:
         logger.error("Error when fetching Artist: %s", e)
         dict_row["Artist"] = "NA"

--- a/tests/test_RymUrl.py
+++ b/tests/test_RymUrl.py
@@ -9,11 +9,8 @@ def test_RymUrlSimple():
 
 
 def test_RymUrlAdvanced():
-    RymUrlTest = RymUrl.RymUrl()
-    RymUrlTest.url_part_type = "/release"
-    RymUrlTest.url_part_origin_countries = "/loc:france"
-    RymUrlTest.url_part_year = "/2010s"
-    RymUrlTest.url_part_genres += "/g:rock"
+    RymUrlTest = RymUrl.RymUrl(kind="release", origin_countries="france", year="2010s", genres="rock")
+
     print(str(RymUrlTest))
     if (
         str(RymUrlTest)


### PR DESCRIPTION
Hello!

Thanks for merging my other PR :)

I thought it would be a good idea to change the chart URL creator so that it can be used like:
```python
url = RymUrl(kind="album", year="2010s", genres="ambient,blues", descriptors="atmosphere,form,theme,bittersweet,epic", origin_countries="algeria,bouvet-island-bouvetoya,europe,antarctica-1", page=1)
# Generates https://rateyourmusic.com/charts/top/album/2010s/g:ambient,blues/loc:algeria,bouvet-island-bouvetoya,europe,antarctica-1/d:atmosphere,form,theme,bittersweet,epic/1/
```

If you think it makes sense like this then I'll also change the documentation in other places.
