### PR TITLE
updated get_chart_infos to grab secondary genres

### DIFF
--- a/rymscraper/utils.py
+++ b/rymscraper/utils.py
@@ -273,6 +273,18 @@ def get_chart_row_infos(row: element.Tag) -> dict:
         logger.error("Error when fetching Genres: %s", e)
         dict_row["Genres"] = "NA"
     try:
+        dict_row["Secondary Genres"] = ", ".join(
+            [
+                x.text
+                for x in row.find(
+                    "div", {"class": "page_charts_section_charts_item_genres_secondary"}
+                ).find_all("a", {"class": "genre"})
+            ]
+        )
+    except Exception as e:
+        logger.error("Error when fetching Secondary Genres (Very likely the album doesn't have secondaries.): %s", e)
+        dict_row["Genres"] = "NA"
+    try:
         dict_row["RYM Rating"] = row.find(
             "span", {"class": "page_charts_section_charts_item_details_average_num"}
         ).text


### PR DESCRIPTION
Quick addition to the chart feature to grab secondary genres and add it to the dictionary. It is worth noting that a small, but considerable amount of albums do not have secondary genres, so I've made a semi-custom error message to let the user know there's probably nothing going wrong, but perhaps it is worth removing entirely, because it can get quite annoying when doing large chart scrapes to have your terminal filled with "errors."